### PR TITLE
Support java.nio.file.Path watch and cross-platform testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,21 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+  			<groupId>com.google.jimfs</groupId>
+  			<artifactId>jimfs</artifactId>
+  			<version>1.1</version>
+  			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+		    <groupId>org.awaitility</groupId>
+		    <artifactId>awaitility</artifactId>
+		    <version>2.0.0</version>
+            <scope>test</scope>
+		</dependency>
+				
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
+++ b/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
@@ -20,6 +20,7 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +31,9 @@ import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -45,17 +49,27 @@ import rx.functions.Action1;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
-
+@RunWith(Parameterized.class)
 public class FileObservableTest {
 
     private FileSystem fileSystem;
+	private Configuration fileSystemConfig;
+    
+    public FileObservableTest(Configuration fileSystemConifg) {
+		this.fileSystemConfig = fileSystemConifg;
+	}
+    
+    @Parameters
+    public static Collection<Configuration> data() {
+		return Arrays
+				.asList(new Configuration[] { Configuration.windows(), Configuration.unix(), Configuration.osX() });
+    }
 
     @Before
 	public void setup() throws IOException {
 		WatchServiceConfiguration watchServiceConfig = WatchServiceConfiguration.polling(10, MILLISECONDS);
-		Configuration fileSystemConfig = Configuration.osX().toBuilder().setWatchServiceConfiguration(watchServiceConfig)
-				.build();
-		this.fileSystem = Jimfs.newFileSystem(fileSystemConfig);
+		Configuration config = fileSystemConfig.toBuilder().setWatchServiceConfiguration(watchServiceConfig).build();
+		this.fileSystem = Jimfs.newFileSystem(config);
 		Path target = fileSystem.getPath("target");
 		Files.createDirectories(target);
 	}

--- a/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
+++ b/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
@@ -2,16 +2,19 @@ package com.github.davidmoten.rx;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
@@ -20,11 +23,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.google.common.jimfs.WatchServiceConfiguration;
 
 import rx.Observable;
 import rx.Observer;
@@ -34,12 +45,26 @@ import rx.functions.Action1;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
+
 public class FileObservableTest {
+
+    private FileSystem fileSystem;
+
+    @Before
+	public void setup() throws IOException {
+		WatchServiceConfiguration watchServiceConfig = WatchServiceConfiguration.polling(10, MILLISECONDS);
+		Configuration fileSystemConfig = Configuration.osX().toBuilder().setWatchServiceConfiguration(watchServiceConfig)
+				.build();
+		this.fileSystem = Jimfs.newFileSystem(fileSystemConfig);
+		Path target = fileSystem.getPath("target");
+		Files.createDirectories(target);
+	}
 
     @Test
     public void testNoEventsThrownIfFileDoesNotExist() throws InterruptedException {
-        File file = new File("target/does-not-exist");
+        Path file = fileSystem.getPath("target", "does-not-exist");
         Observable<WatchEvent<?>> events = FileObservable.from(file, ENTRY_MODIFY);
+        
         final CountDownLatch latch = new CountDownLatch(1);
         Subscription sub = events.subscribeOn(Schedulers.io())
                 .subscribe(new Observer<WatchEvent<?>>() {
@@ -60,6 +85,7 @@ public class FileObservableTest {
                         latch.countDown();
                     }
                 });
+        
         assertFalse(latch.await(100, TimeUnit.MILLISECONDS));
         sub.unsubscribe();
     }
@@ -67,45 +93,52 @@ public class FileObservableTest {
     @Test
     public void testCreateAndModifyEventsForANonDirectoryFileBlockForever()
             throws InterruptedException, IOException {
-        File file = new File("target/f");
+    	Path file = fileSystem.getPath("target", "f");
         Observable<WatchEvent<?>> events = FileObservable.from(file).kind(ENTRY_MODIFY)
                 .kind(ENTRY_CREATE).events();
+                        
         checkCreateAndModifyEvents(file, events);
     }
 
     @Test
     public void testCreateAndModifyEventsForANonDirectoryFilePollEveryInterval()
             throws InterruptedException, IOException {
-        File file = new File("target/f");
+    	Path file = fileSystem.getPath("target", "f");
         Observable<WatchEvent<?>> events = FileObservable.from(file).kind(ENTRY_MODIFY)
                 .kind(ENTRY_CREATE).pollInterval(100, TimeUnit.MILLISECONDS).events();
+        
         checkCreateAndModifyEvents(file, events);
     }
 
     @Test
     public void testCreateAndModifyEventsForANonDirectoryFileBlockingPollEveryInterval()
             throws InterruptedException, IOException {
-        File file = new File("target/f");
+    	Path file = fileSystem.getPath("target", "f");
         Observable<WatchEvent<?>> events = FileObservable.from(file).kind(ENTRY_MODIFY)
                 .kind(ENTRY_CREATE).pollInterval(100, TimeUnit.MILLISECONDS)
                 .pollDuration(100, TimeUnit.MILLISECONDS).events();
+        
         checkCreateAndModifyEvents(file, events);
     }
 
-    private void checkCreateAndModifyEvents(File file, Observable<WatchEvent<?>> events)
+    private void checkCreateAndModifyEvents(Path file, Observable<WatchEvent<?>> events)
             throws InterruptedException, IOException, FileNotFoundException {
-        file.delete();
-        final CountDownLatch latch = new CountDownLatch(1);
+    	Files.deleteIfExists(file);
+        
         @SuppressWarnings("unchecked")
         final List<Kind<?>> eventKinds = Mockito.mock(List.class);
         InOrder inOrder = Mockito.inOrder(eventKinds);
-        final AtomicInteger errorCount = new AtomicInteger(0);
+        
+        final AtomicBoolean isComplete = new AtomicBoolean();
+        final AtomicInteger eventCount = new AtomicInteger();
+        final AtomicInteger errorCount = new AtomicInteger();
+        
         Subscription sub = events.subscribeOn(Schedulers.io())
                 .subscribe(new Observer<WatchEvent<?>>() {
 
                     @Override
                     public void onCompleted() {
-                        System.out.println("completed");
+                    	isComplete.set(true);
                     }
 
                     @Override
@@ -115,34 +148,40 @@ public class FileObservableTest {
 
                     @Override
                     public void onNext(WatchEvent<?> event) {
-                        System.out.println("event=" + event);
                         eventKinds.add(event.kind());
-                        latch.countDown();
+                        eventCount.incrementAndGet();
                     }
                 });
-        // sleep long enough for WatchService to start
-        Thread.sleep(1000);
-        file.createNewFile();
-        FileOutputStream fos = new FileOutputStream(file, true);
-        fos.write("hello there".getBytes());
-        fos.close();
-        // give the WatchService time to register the change
-        Thread.sleep(100);
-        assertTrue(latch.await(30000, TimeUnit.MILLISECONDS));
+
+        sleepForWatchEvent();
+        
+        Files.createFile(file);
+        await().untilAtomic(eventCount, equalTo(1));
+        
+        Files.write(file, "hello there".getBytes(),StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        await().untilAtomic(eventCount, equalTo(2));
+                
         inOrder.verify(eventKinds).add(StandardWatchEventKinds.ENTRY_CREATE);
         inOrder.verify(eventKinds).add(StandardWatchEventKinds.ENTRY_MODIFY);
         inOrder.verifyNoMoreInteractions();
 
-        sub.unsubscribe();
-        Thread.sleep(100);
+        sub.unsubscribe();        
         assertEquals(0, errorCount.get());
     }
 
+	private ConditionFactory await() {
+		return Awaitility.await().with().pollInterval(10, MILLISECONDS).atMost(200, MILLISECONDS);
+	}
+
+	private void sleepForWatchEvent() throws InterruptedException {
+		Thread.sleep(20);
+	}
+
     @Test
     public void testFileTailingFromStartOfFile() throws InterruptedException, IOException {
-        final File log = new File("target/test.log");
-        log.delete();
-        log.createNewFile();
+    	final Path log = fileSystem.getPath("target", "test.log");
+    	Files.deleteIfExists(log);
+    	Files.createFile(log);
         append(log, "a0");
 
         Observable<String> tailer = FileObservable.tailer().file(log).onWatchStarted(new Action0() {
@@ -152,136 +191,145 @@ public class FileObservableTest {
                 append(log, "a2");
             }
         }).sampleTimeMs(50).utf8().tailText();
-        final List<String> list = new ArrayList<String>();
-        final CountDownLatch latch = new CountDownLatch(3);
+        
+        final List<String> list = new ArrayList<>();
+        final AtomicInteger eventCount = new AtomicInteger();
+        
         Subscription sub = tailer.subscribeOn(Schedulers.io()).subscribe(new Action1<String>() {
             @Override
             public void call(String line) {
-                System.out.println("received: '" + line + "'");
                 list.add(line);
-                latch.countDown();
+                eventCount.incrementAndGet();
             }
         });
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
+                
+        await().untilAtomic(eventCount, equalTo(3));
         assertEquals(Arrays.asList("a0", "a1", "a2"), list);
+        
         sub.unsubscribe();
     }
-
+    
     @Test
     public void testFileTailingWhenFileIsCreatedAfterSubscription()
             throws InterruptedException, IOException {
-        final File log = new File("target/test.log");
-        log.delete();
-
+    	final Path log = fileSystem.getPath("target", "test.log");
+    	Files.deleteIfExists(log);
         append(log, "a0");
-        Observable<String> tailer = FileObservable.tailer().file(log).startPosition(0)
-                .sampleTimeMs(50).utf8().onWatchStarted(new Action0() {
-                    @Override
-                    public void call() {
-                        try {
-                            log.createNewFile();
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                        append(log, "a1");
-                        append(log, "a2");
-                    }
-                }).tailText();
+        
+		Observable<String> tailer = FileObservable.tailer().file(log).startPosition(0).sampleTimeMs(50).utf8()
+				.onWatchStarted(new Action0() {
+					@Override
+					public void call() {
+						try {
+							if (!Files.exists(log)) {
+								Files.createFile(log);
+							}
+						} catch (IOException e) {
+							throw new RuntimeException(e);
+						}
+						append(log, "a1");
+						append(log, "a2");
+					}
+				}).tailText();
 
         final List<String> list = new ArrayList<String>();
-        final CountDownLatch latch = new CountDownLatch(3);
+        final AtomicInteger eventCount = new AtomicInteger();
+        
         Subscription sub = tailer.subscribeOn(Schedulers.io()).subscribe(new Action1<String>() {
             @Override
             public void call(String line) {
-                System.out.println("received: '" + line + "'");
                 list.add(line);
-                latch.countDown();
+                eventCount.incrementAndGet();
             }
         });
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        
+        await().untilAtomic(eventCount, equalTo(3));
         assertEquals(Arrays.asList("a0", "a1", "a2"), list);
+        
         sub.unsubscribe();
     }
-
-    private static void append(File file, String line) {
-        try {
-            FileOutputStream fos = new FileOutputStream(file, true);
-            fos.write(line.getBytes(Charset.forName("UTF-8")));
-            fos.write('\n');
-            fos.close();
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
+   
     @Test
     public void testTailTextFileStreamsFromEndOfFileIfSpecified()
-            throws FileNotFoundException, InterruptedException {
-        File file = new File("target/test1.txt");
-        file.delete();
-        try (PrintStream out = new PrintStream(file)) {
-            out.println("line 1");
-        }
-        final List<String> list = new ArrayList<String>();
+            throws InterruptedException, IOException {   	        
+        Path file = fileSystem.getPath("target", "test1.txt");
+    	Files.deleteIfExists(file);
+    	append(file, "line 1");
+        
+        final List<String> list = new ArrayList<>();
         TestSubscriber<String> ts = TestSubscriber.create();
-        FileObservable.tailer().file(file).startPosition(file.length()).sampleTimeMs(10).utf8()
+        final AtomicInteger eventCount = new AtomicInteger();
+        
+        FileObservable.tailer().file(file).startPosition(Files.size(file)).sampleTimeMs(10).utf8()
                 .tailText()
                 // for each
                 .doOnNext(new Action1<String>() {
-
                     @Override
                     public void call(String line) {
-                        System.out.println(line);
                         list.add(line);
+                        eventCount.incrementAndGet();
                     }
                 }).subscribeOn(Schedulers.newThread()).subscribe(ts);
-        Thread.sleep(1100);
+        
+        sleepForWatchEvent();
+        
         assertTrue(list.isEmpty());
-        try (PrintStream out = new PrintStream(new FileOutputStream(file, true))) {
-            out.println("line 2");
-        }
-        Thread.sleep(1100);
+        
+        append(file, "line 2");
+        await().untilAtomic(eventCount, equalTo(1));
         assertEquals(1, list.size());
         assertEquals("line 2", list.get(0).trim());
+        
         ts.unsubscribe();
     }
 
     @Test
     public void testTailTextFileStreamsFromEndOfFileIfDeleteOccurs()
             throws InterruptedException, IOException {
-        File file = new File("target/test2.txt");
-        file.delete();
-        try (PrintStream out = new PrintStream(file)) {
-            out.println("line 1");
-        }
+    	Path file = fileSystem.getPath("target", "test2.txt");
+    	Files.deleteIfExists(file);
+    	append(file, "hello there");
+    	
         final List<String> list = new ArrayList<String>();
-        Subscription sub = FileObservable.tailer().file(file).startPosition(file.length())
+        final AtomicInteger eventCount = new AtomicInteger();
+        
+        Subscription sub = FileObservable.tailer().file(file).startPosition(Files.size(file))
                 .sampleTimeMs(10).utf8().tailText()
                 // for each
                 .doOnNext(new Action1<String>() {
-
                     @Override
                     public void call(String line) {
-                        System.out.println(line);
                         list.add(line);
+                        eventCount.incrementAndGet();
                     }
                 }).subscribeOn(Schedulers.newThread()).subscribe();
-        // delay must be long enough for last update timestamp to change on
-        // windows (resolution to the second)
-        Thread.sleep(1100);
+
+        sleepForWatchEvent();
+        
         assertTrue(list.isEmpty());
+        
         // delete file then make it bigger than it was
-        assertTrue(file.delete());
-        try (PrintStream out = new PrintStream(new FileOutputStream(file, true))) {
-            out.println("line 2");
-            out.println("line 3");
-        }
-        Thread.sleep(1100);
+        assertTrue(Files.deleteIfExists(file));
+        sleepForWatchEvent();        
+                
+        append(file, "line 2");
+        await().untilAtomic(eventCount, equalTo(1));
+        
+        append(file, "line 3");
+        await().untilAtomic(eventCount, equalTo(2));
+                        
         assertEquals(2, list.size());
         assertEquals("line 2", list.get(0).trim());
         assertEquals("line 3", list.get(1).trim());
+        
         sub.unsubscribe();
+    }
+    
+    private static void append(Path file, String line) {
+    	try {
+			Files.write(file, (line + "\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.WRITE);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
     }
 }

--- a/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
+++ b/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
@@ -184,7 +184,7 @@ public class FileObservableTest {
     }
 
 	private ConditionFactory await() {
-		return Awaitility.await().with().pollInterval(10, MILLISECONDS).atMost(200, MILLISECONDS);
+		return Awaitility.await().with().pollInterval(10, MILLISECONDS).atMost(2000, MILLISECONDS);
 	}
 
 	private void sleepForWatchEvent() throws InterruptedException {

--- a/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
+++ b/src/test/java/com/github/davidmoten/rx/FileObservableTest.java
@@ -78,7 +78,7 @@ public class FileObservableTest {
     public void testNoEventsThrownIfFileDoesNotExist() throws InterruptedException {
         Path file = fileSystem.getPath("target", "does-not-exist");
         Observable<WatchEvent<?>> events = FileObservable.from(file, ENTRY_MODIFY);
-        
+           
         final CountDownLatch latch = new CountDownLatch(1);
         Subscription sub = events.subscribeOn(Schedulers.io())
                 .subscribe(new Observer<WatchEvent<?>>() {
@@ -100,6 +100,8 @@ public class FileObservableTest {
                     }
                 });
         
+        sleepForWatchEvent();
+                
         assertFalse(latch.await(100, TimeUnit.MILLISECONDS));
         sub.unsubscribe();
     }
@@ -146,7 +148,7 @@ public class FileObservableTest {
         final AtomicBoolean isComplete = new AtomicBoolean();
         final AtomicInteger eventCount = new AtomicInteger();
         final AtomicInteger errorCount = new AtomicInteger();
-        
+                
         Subscription sub = events.subscribeOn(Schedulers.io())
                 .subscribe(new Observer<WatchEvent<?>>() {
 
@@ -166,7 +168,7 @@ public class FileObservableTest {
                         eventCount.incrementAndGet();
                     }
                 });
-
+        
         sleepForWatchEvent();
         
         Files.createFile(file);
@@ -205,9 +207,11 @@ public class FileObservableTest {
                 append(log, "a2");
             }
         }).sampleTimeMs(50).utf8().tailText();
-        
+                
         final List<String> list = new ArrayList<>();
         final AtomicInteger eventCount = new AtomicInteger();
+        
+        sleepForWatchEvent();
         
         Subscription sub = tailer.subscribeOn(Schedulers.io()).subscribe(new Action1<String>() {
             @Override
@@ -216,7 +220,7 @@ public class FileObservableTest {
                 eventCount.incrementAndGet();
             }
         });
-                
+                        
         await().untilAtomic(eventCount, equalTo(3));
         assertEquals(Arrays.asList("a0", "a1", "a2"), list);
         
@@ -245,6 +249,8 @@ public class FileObservableTest {
 						append(log, "a2");
 					}
 				}).tailText();
+		
+		sleepForWatchEvent();
 
         final List<String> list = new ArrayList<String>();
         final AtomicInteger eventCount = new AtomicInteger();
@@ -256,7 +262,7 @@ public class FileObservableTest {
                 eventCount.incrementAndGet();
             }
         });
-        
+                
         await().untilAtomic(eventCount, equalTo(3));
         assertEquals(Arrays.asList("a0", "a1", "a2"), list);
         
@@ -273,7 +279,7 @@ public class FileObservableTest {
         final List<String> list = new ArrayList<>();
         TestSubscriber<String> ts = TestSubscriber.create();
         final AtomicInteger eventCount = new AtomicInteger();
-        
+                
         FileObservable.tailer().file(file).startPosition(Files.size(file)).sampleTimeMs(10).utf8()
                 .tailText()
                 // for each
@@ -286,7 +292,7 @@ public class FileObservableTest {
                 }).subscribeOn(Schedulers.newThread()).subscribe(ts);
         
         sleepForWatchEvent();
-        
+                
         assertTrue(list.isEmpty());
         
         append(file, "line 2");
@@ -307,6 +313,8 @@ public class FileObservableTest {
         final List<String> list = new ArrayList<String>();
         final AtomicInteger eventCount = new AtomicInteger();
         
+        sleepForWatchEvent();
+        
         Subscription sub = FileObservable.tailer().file(file).startPosition(Files.size(file))
                 .sampleTimeMs(10).utf8().tailText()
                 // for each
@@ -317,8 +325,6 @@ public class FileObservableTest {
                         eventCount.incrementAndGet();
                     }
                 }).subscribeOn(Schedulers.newThread()).subscribe();
-
-        sleepForWatchEvent();
         
         assertTrue(list.isEmpty());
         


### PR DESCRIPTION
Overloaded methods were added to the ```FileObservable``` class to provide a ```Path``` object (vs the existing ```File``` object method signature).  While you could technically just have called file.toPath(), a path based API is seems to be the favored approach moving forward, most likely due to..... the ability to finally effectively test a Java FileSystem without relying on the underlying platform running the tests!  Google's excellent [jimfs](https://github.com/google/jimfs) gives the power to do pure in-memory file based testing and make unit testing a breeze.